### PR TITLE
Align brace system cards in a single column

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -268,7 +268,7 @@ body {
 
 .services-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: 1fr;
     gap: 2rem;
 }
 


### PR DESCRIPTION
## Summary
- display all brace system cards in a vertical list for better alignment

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68890cdc0760832e87eae2b0f231887f