### PR TITLE
Center advantage section icons

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -353,15 +353,22 @@ body {
     margin: 0 auto;
 }
 
+.advantages-list {
+    text-align: center;
+}
+
 .advantage-items {
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
 }
 
+
 .advantage-item {
     display: flex;
-    align-items: flex-start;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
     gap: 1rem;
 }
 
@@ -375,6 +382,7 @@ body {
     justify-content: center;
     color: white;
     flex-shrink: 0;
+    margin-bottom: 0.5rem;
 }
 
 .advantage-title {


### PR DESCRIPTION
## Summary
- center the items in the Advantages list
- stack icons above their descriptions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68890e3b44c8832e910423fee84fa1c7