### PR TITLE
Center elements on <=1024px screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -791,6 +791,10 @@ body {
         text-align: center;
     }
 
+    .contact-social-title {
+        text-align: center;
+    }
+
   .contact-social-links {
       justify-items: center;
       justify-content: center;


### PR DESCRIPTION
## Summary
- center the "Contact" heading on small screens
- keep contact social icons centered

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889e002ac40832e9f19f02b1b9199ba