### PR TITLE
Align service card icons and titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,12 +149,14 @@
             <h2 class="section-title">Используемые брекет-системы</h2>
             <div class="services-grid">
                 <div class="service-card service-card-blue">
-                    <div class="service-icon">
-                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
-                        </svg>
+                    <div class="service-header">
+                        <div class="service-icon">
+                            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+                            </svg>
+                        </div>
+                        <h3 class="service-title">Damon System</h3>
                     </div>
-                    <h3 class="service-title">Damon System</h3>
                     <p class="service-description">
                         Самолигирующие брекеты от Ormco. Более мягкое давление, быстрая установка, 
                         меньший дискомфорт для пациента.
@@ -167,12 +169,14 @@
                 </div>
                 
                 <div class="service-card service-card-gray">
-                    <div class="service-icon">
-                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
-                        </svg>
+                    <div class="service-header">
+                        <div class="service-icon">
+                            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+                            </svg>
+                        </div>
+                        <h3 class="service-title">American Orthodontics</h3>
                     </div>
-                    <h3 class="service-title">American Orthodontics</h3>
                     <p class="service-description">
                         Оригинальные брекеты высокого качества, произведенные в США. 
                         Вся серия брекетов от ведущего американского производителя.
@@ -185,12 +189,14 @@
                 </div>
                 
                 <div class="service-card service-card-green">
-                    <div class="service-icon">
-                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
-                        </svg>
+                    <div class="service-header">
+                        <div class="service-icon">
+                            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+                            </svg>
+                        </div>
+                        <h3 class="service-title">3M & Forestadent</h3>
                     </div>
-                    <h3 class="service-title">3M & Forestadent</h3>
                     <p class="service-description">
                         Полная серия брекетов от ведущих мировых производителей. 
                         Получаю новинки на 6-12 месяцев раньше официальных дилеров.

--- a/styles.css
+++ b/styles.css
@@ -296,16 +296,23 @@ body {
     background: linear-gradient(135deg, #dcfce7, #bbf7d0);
 }
 
+.service-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
 .service-icon {
-    width: 64px;
-    height: 64px;
+    width: 48px;
+    height: 48px;
     background: #2563eb;
     border-radius: 12px;
     display: flex;
     align-items: center;
     justify-content: center;
     color: white;
-    margin-bottom: 1.5rem;
+    flex-shrink: 0;
 }
 
 .service-card-gray .service-icon {
@@ -319,7 +326,7 @@ body {
 .service-title {
     font-size: 1.25rem;
     font-weight: 600;
-    margin-bottom: 1rem;
+    margin-bottom: 0;
     color: #1e293b;
 }
 


### PR DESCRIPTION
## Summary
- group service icons and titles into a shared header
- style the new header so icons and titles align horizontally
- resize service icons so proportionally match advantage section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889e3eb1888832eb6900dc633966b83