### PR TITLE
Add Google Analytics tracking snippet

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="ru">
 <head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YZZBEFYTCQ"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-YZZBEFYTCQ');
+    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Доктор Antonis Kyriacou - Ортодонт | Пафос, Кипр</title>


### PR DESCRIPTION
## Summary
- embed Google Tag Manager loading script and configuration directly after the `<head>` tag in `index.html` for analytics tracking

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689205b14524832ea13d595874145384