### PR TITLE
Center education section on tablets

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -744,28 +744,32 @@ body {
     }
 
     .subsection-title {
-    margin-bottom: 3rem;
+        margin-bottom: 3rem;
+        text-align: center;
     }
 
     .check-icon {
         display: block;
-        position: relative;
-        top: 100%;
-        left: 50%;
-        transform: translateY(-120%);
+        margin: 0 auto 0.5rem;
+        position: static;
+        transform: none;
     }
 
     .education-details {
         margin-bottom: 10px;
+        text-align: center;
     }
 
     .education-item {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
         margin: 0 auto;
     }
 
     .social-links {
-    margin-bottom: 2rem;
-}
+        margin-bottom: 2rem;
+    }
 
 
     .stats-grid {


### PR DESCRIPTION
## Summary
- Center subsection titles at tablet sizes for improved readability
- Simplify check icon layout and center it on smaller screens
- Rework education items into centered flex columns

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python3 - <<'PY' ...` to verify CSS rules

------
https://chatgpt.com/codex/tasks/task_e_68950f7c093c832ea8e0179a901759ba