### PR TITLE
style: adjust education icons for responsive layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -214,7 +214,9 @@ body {
 .check-icon {
     width: 24px;
     height: 24px;
-    color: #1e293b;
+    background: #2563eb;
+    color: #ffffff;
+    border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -751,6 +753,9 @@ body {
         margin: 0 auto 0.5rem;
         position: static;
         transform: none;
+        background: none;
+        color: #1e293b;
+        border-radius: 0;
     }
 
     .education-details {


### PR DESCRIPTION
## Summary
- restore blue circular background and white checkmarks for education items on large screens
- drop background and use dark checkmarks on screens <=1024px

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689513092340832e8558c7c1ef264358